### PR TITLE
Add zoom/pan to image preview dialogs (ImageSelector + MultiImage)

### DIFF
--- a/src/assets/i18n/en/translation.json
+++ b/src/assets/i18n/en/translation.json
@@ -122,6 +122,7 @@
 			}
 		},
 		"file-upload": {
+			"close": "Close",
 			"upload": "Upload",
 			"upload-capture": {
 				"image": "Take photo"

--- a/src/standalone/FileUpload/FileUpload.stories.tsx
+++ b/src/standalone/FileUpload/FileUpload.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+// eslint-disable-next-line import/no-unresolved
+import { expect, within } from "storybook/test";
 import { FileUploadGeneric, ImageSelector } from "./index";
 import type { FileData, FileMeta } from "./Generic";
 import type { MultiImageImage } from "./MultiImage/MultiImage";
@@ -126,8 +128,69 @@ export const ReadOnly: FUGStory = {
 };
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeColorImage = (color: string, accent: string, size = 128): string => {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d");
+	// background
+	ctx.fillStyle = color;
+	ctx.fillRect(0, 0, size, size);
+	// checkerboard
+	ctx.fillStyle = accent;
+	const cell = size / 8;
+	for (let r = 0; r < 8; r++) {
+		for (let c = 0; c < 8; c++) {
+			if ((r + c) % 2 === 0) ctx.fillRect(c * cell, r * cell, cell, cell);
+		}
+	}
+	// diagonal cross
+	ctx.strokeStyle = accent;
+	ctx.lineWidth = 3;
+	ctx.beginPath();
+	ctx.moveTo(0, 0);
+	ctx.lineTo(size, size);
+	ctx.moveTo(size, 0);
+	ctx.lineTo(0, size);
+	ctx.stroke();
+	// center circle
+	ctx.beginPath();
+	ctx.arc(size / 2, size / 2, size / 4, 0, Math.PI * 2);
+	ctx.fillStyle = color;
+	ctx.fill();
+	ctx.stroke();
+	return canvas.toDataURL("image/png");
+};
+
+// ---------------------------------------------------------------------------
 // ImageSelector stories
 // ---------------------------------------------------------------------------
+
+export const ImageSelectorModern: StoryObj = {
+	name: "ImageSelector — modern (with preview dialog)",
+	render: () => {
+		const [value, setValue] = useState(makeColorImage("#e53935", "#ffcdd2"));
+		return (
+			<div style={{ width: 300, height: 200 }}>
+				<ImageSelector
+					name="photo"
+					value={value}
+					capture={false}
+					alt="Photo"
+					label="Photo (modern — click image to preview)"
+					readOnly={false}
+					variant="modern"
+					onChange={(_name, val) => {
+						setValue(val);
+					}}
+				/>
+			</div>
+		);
+	},
+};
 
 export const ImageSelectorEmpty: StoryObj = {
 	name: "ImageSelector — empty",
@@ -203,8 +266,7 @@ export const ImageSelectorReadOnly: StoryObj = {
 export const MultiImageEmpty: StoryObj = {
 	name: "MultiImage — empty",
 	render: () => {
-		const placeholder =
-			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+		const placeholder = makeColorImage("#ccc", "#999");
 
 		const [images, setImages] = useState<MultiImageImage[]>([]);
 
@@ -233,13 +295,11 @@ export const MultiImageEmpty: StoryObj = {
 export const MultiImageWithImages: StoryObj = {
 	name: "MultiImage — with images",
 	render: () => {
-		const redPixel =
-			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==";
-		const greenPixel =
-			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+		const redImage = makeColorImage("#e53935", "#ffcdd2");
+		const greenImage = makeColorImage("#43a047", "#c8e6c9");
 		const initialImages: MultiImageImage[] = [
-			{ id: "img-1", image: redPixel, name: "red.png" },
-			{ id: "img-2", image: greenPixel, name: "green.png" },
+			{ id: "img-1", image: redImage, name: "red.png" },
+			{ id: "img-2", image: greenImage, name: "green.png" },
 		];
 
 		const [images, setImages] = useState<MultiImageImage[]>(initialImages);
@@ -251,8 +311,8 @@ export const MultiImageWithImages: StoryObj = {
 					label="Product images"
 					images={images}
 					primary={primary}
-					uploadImage={redPixel}
-					captureImage={redPixel}
+					uploadImage={redImage}
+					captureImage={redImage}
 					onChange={(_name, imgs) => {
 						setImages(imgs);
 					}}
@@ -262,6 +322,83 @@ export const MultiImageWithImages: StoryObj = {
 				/>
 			</div>
 		);
+	},
+};
+
+export const MultiImageWheelDoesNotSwitchImage: StoryObj = {
+	name: "MultiImage — wheel zoom must not switch image",
+	render: () => {
+		const redImage = makeColorImage("#e53935", "#ffcdd2");
+		const greenImage = makeColorImage("#43a047", "#c8e6c9");
+		const initialImages: MultiImageImage[] = [
+			{ id: "img-1", image: redImage, name: "red.png" },
+			{ id: "img-2", image: greenImage, name: "green.png" },
+		];
+		const [images, setImages] = useState<MultiImageImage[]>(initialImages);
+		const [primary, setPrimary] = useState<string | null>("img-1");
+		return (
+			<div style={{ width: 300, height: 300 }}>
+				<MultiImage
+					label="Wheel test"
+					images={images}
+					primary={primary}
+					uploadImage={redImage}
+					captureImage={redImage}
+					onChange={(_name, imgs) => {
+						setImages(imgs);
+					}}
+					onPrimaryChange={(_name, p) => {
+						setPrimary(p);
+					}}
+				/>
+			</div>
+		);
+	},
+	play: async ({ canvasElement, userEvent }) => {
+		// Click the first image to open the fullscreen dialog
+		const previewImage = canvasElement.querySelector("img");
+		if (!previewImage) throw new Error("preview img not found");
+		await userEvent.click(previewImage);
+
+		// Find the dialog (rendered in a portal)
+		const body = within(document.body);
+		const dialog = await body.findByRole("dialog");
+
+		// Find the dialog image
+		const dialogImg = dialog.querySelector("img");
+		if (!dialogImg) throw new Error("dialog img not found");
+		const initialSrc = dialogImg.getAttribute("src");
+
+		// Click next arrow to go to second image
+		const arrowIcon = dialog.querySelector("[data-testid='ArrowForwardIcon']");
+		if (!arrowIcon) throw new Error("ArrowForwardIcon not found");
+		const nextButton = arrowIcon.closest("button");
+		if (!nextButton) throw new Error("next button not found");
+		await userEvent.click(nextButton);
+
+		// Wait for image to update and scroll reset to settle
+		await new Promise((r) => setTimeout(r, 500));
+		const secondSrc = dialogImg.getAttribute("src");
+		await expect(secondSrc).not.toBe(initialSrc);
+
+		// Fire a wheel-up event (zoom in) on the zoom container.
+		// stopPropagation prevents it from reaching the SwipeListener.
+		const zoomContainer = dialogImg.parentElement;
+		if (!zoomContainer) throw new Error("zoom container not found");
+		zoomContainer.dispatchEvent(
+			new WheelEvent("wheel", {
+				deltaY: -120,
+				bubbles: true,
+				cancelable: true,
+			}),
+		);
+
+		// Wait for any scroll handlers to fire
+		await new Promise((r) => setTimeout(r, 500));
+
+		// The image src must still be the second image — not switched back
+		const srcAfterWheel = dialogImg.getAttribute("src");
+		await expect(srcAfterWheel).toBe(secondSrc);
 	},
 };
 

--- a/src/standalone/FileUpload/Image/ImagePreviewDialog.stories.tsx
+++ b/src/standalone/FileUpload/Image/ImagePreviewDialog.stories.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+// eslint-disable-next-line import/no-unresolved
+import { fn, expect, within } from "storybook/test";
+import ImagePreviewDialog from "./ImagePreviewDialog";
+import { Button } from "@mui/material";
+
+// A small checkerboard SVG so zooming is visually meaningful
+const CHECKER_IMAGE =
+	"data:image/svg+xml;base64," +
+	btoa(`<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<rect width="200" height="200" fill="#fff"/>
+<rect x="0" y="0" width="50" height="50" fill="#4caf50"/>
+<rect x="100" y="0" width="50" height="50" fill="#4caf50"/>
+<rect x="50" y="50" width="50" height="50" fill="#4caf50"/>
+<rect x="150" y="50" width="50" height="50" fill="#4caf50"/>
+<rect x="0" y="100" width="50" height="50" fill="#4caf50"/>
+<rect x="100" y="100" width="50" height="50" fill="#4caf50"/>
+<rect x="50" y="150" width="50" height="50" fill="#4caf50"/>
+<rect x="150" y="150" width="50" height="50" fill="#4caf50"/>
+</svg>`);
+
+const meta: Meta<typeof ImagePreviewDialog> = {
+	title: "Standalone/FileUpload/ImagePreviewDialog",
+	component: ImagePreviewDialog,
+	parameters: { layout: "centered" },
+	args: {
+		src: CHECKER_IMAGE,
+		alt: "Test image",
+		open: false,
+		onClose: fn(),
+	},
+};
+export default meta;
+
+type Story = StoryObj<typeof ImagePreviewDialog>;
+
+// ---------------------------------------------------------------------------
+// Interactive story — user opens/closes the dialog
+// ---------------------------------------------------------------------------
+
+const InteractiveTemplate = () => {
+	const [open, setOpen] = useState(false);
+	return (
+		<>
+			<Button variant="contained" onClick={() => setOpen(true)}>
+				Open preview
+			</Button>
+			<ImagePreviewDialog
+				src={CHECKER_IMAGE}
+				alt="Checkerboard"
+				open={open}
+				onClose={() => setOpen(false)}
+			/>
+		</>
+	);
+};
+
+export const Interactive: Story = {
+	render: () => <InteractiveTemplate />,
+};
+
+// ---------------------------------------------------------------------------
+// Wheel zoom — tests the real open-from-closed flow
+// ---------------------------------------------------------------------------
+
+export const WheelZoom: Story = {
+	render: () => <InteractiveTemplate />,
+	play: async ({ canvas, userEvent }) => {
+		// Open the dialog via button click (starts closed, like real usage)
+		const openBtn = await canvas.findByText("Open preview");
+		await userEvent.click(openBtn);
+
+		const body = within(document.body);
+		const dialog = await body.findByRole("dialog");
+		const image = dialog.querySelector("img");
+		if (!image) throw new Error("img not found in dialog");
+
+		// Initial state: zoom 1
+		await expect(image.style.transform).toContain("scale(1)");
+
+		// Dispatch a native wheel event (zoom in) on the container
+		const container = image.parentElement;
+		if (!container) throw new Error("image parent not found");
+		container.dispatchEvent(
+			new WheelEvent("wheel", {
+				deltaY: -120,
+				bubbles: true,
+				cancelable: true,
+			}),
+		);
+
+		await new Promise((r) => setTimeout(r, 100));
+
+		// Should be zoomed in (scale > 1)
+		const match = image.style.transform.match(/scale\(([^)]+)\)/);
+		const scale = match ? parseFloat(match[1]) : 1;
+		await expect(scale).toBeGreaterThan(1);
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Opens the dialog and verifies close button works
+// ---------------------------------------------------------------------------
+
+export const OpensAndCloses: Story = {
+	args: {
+		open: true,
+	},
+	play: async ({ userEvent, args }) => {
+		// Dialog renders in a portal, so query from document body
+		const body = within(document.body);
+		const dialog = await body.findByRole("dialog");
+		const screen = within(dialog);
+		const closeButton = await screen.findByRole("button");
+		await userEvent.click(closeButton);
+		await expect(args.onClose).toHaveBeenCalled();
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Verifies the image is rendered
+// ---------------------------------------------------------------------------
+
+export const RendersImage: Story = {
+	args: {
+		open: true,
+	},
+	play: async () => {
+		const body = within(document.body);
+		const dialog = await body.findByRole("dialog");
+		const screen = within(dialog);
+		const image = await screen.findByRole("img");
+		await expect(image).toBeInTheDocument();
+		await expect(image).toHaveAttribute("alt", "Test image");
+		await expect(image).toHaveAttribute("src");
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Double-click toggles zoom
+// ---------------------------------------------------------------------------
+
+export const DoubleClickZoom: Story = {
+	args: {
+		open: true,
+	},
+	play: async ({ userEvent }) => {
+		const body = within(document.body);
+		const dialog = await body.findByRole("dialog");
+		const screen = within(dialog);
+		const image = await screen.findByRole("img");
+		const container = image.parentElement;
+		if (!container) throw new Error("container not found");
+
+		// Initial state: no zoom (scale 1)
+		await expect(image.style.transform).toContain("scale(1)");
+
+		// Double-click the container to zoom in
+		await userEvent.dblClick(container);
+
+		// Should now be zoomed to 2x
+		await expect(image.style.transform).toContain("scale(2)");
+
+		// Double-click again to zoom back out
+		await userEvent.dblClick(container);
+		await expect(image.style.transform).toContain("scale(1)");
+	},
+};

--- a/src/standalone/FileUpload/Image/ImagePreviewDialog.tsx
+++ b/src/standalone/FileUpload/Image/ImagePreviewDialog.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { Dialog, IconButton, styled, useThemeProps } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import useImageZoomPan from "../../../utils/useImageZoomPan";
+import useCCTranslations from "../../../utils/useCCTranslations";
+
+export interface ImagePreviewDialogProps {
+	/**
+	 * The image source (data URI or URL)
+	 */
+	src: string;
+	/**
+	 * Alt text for the image
+	 */
+	alt: string;
+	/**
+	 * Whether the dialog is open
+	 */
+	open: boolean;
+	/**
+	 * Called when the dialog should close
+	 */
+	onClose: () => void;
+	/**
+	 * Custom styles
+	 */
+	classes?: Partial<Record<ImagePreviewDialogClassKey, string>>;
+}
+
+const Root = styled(Dialog, {
+	name: "CcImagePreviewDialog",
+	slot: "root",
+})({});
+
+const CloseButton = styled(IconButton, {
+	name: "CcImagePreviewDialog",
+	slot: "closeButton",
+})(({ theme }) => ({
+	position: "absolute",
+	top: theme.spacing(2),
+	right: theme.spacing(2),
+	zIndex: 1,
+}));
+
+const Container = styled("div", {
+	name: "CcImagePreviewDialog",
+	slot: "container",
+})({
+	width: "100%",
+	height: "100%",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	cursor: "grab",
+	"&:active": {
+		cursor: "grabbing",
+	},
+});
+
+const PreviewImage = styled("img", {
+	name: "CcImagePreviewDialog",
+	slot: "image",
+})({
+	objectFit: "contain",
+	display: "block",
+	width: "100%",
+	height: "100%",
+	pointerEvents: "none",
+	userSelect: "none",
+});
+
+export type ImagePreviewDialogClassKey =
+	| "root"
+	| "closeButton"
+	| "container"
+	| "image";
+
+const ImagePreviewDialog = (inProps: ImagePreviewDialogProps) => {
+	const props = useThemeProps({
+		props: inProps,
+		name: "CcImagePreviewDialog",
+	});
+	const { src, alt, open, onClose, classes } = props;
+	const { t } = useCCTranslations();
+	const { imgRef, containerRef, containerProps } = useImageZoomPan(open);
+
+	return (
+		<Root open={open} fullScreen onClose={onClose} className={classes?.root}>
+			<CloseButton
+				onClick={onClose}
+				aria-label={t("standalone.file-upload.close") ?? "Close"}
+				className={classes?.closeButton}
+			>
+				<CloseIcon />
+			</CloseButton>
+			<Container
+				ref={containerRef}
+				{...containerProps}
+				className={classes?.container}
+			>
+				<PreviewImage
+					ref={imgRef}
+					src={src}
+					alt={alt}
+					className={classes?.image}
+					draggable={false}
+				/>
+			</Container>
+		</Root>
+	);
+};
+
+export default React.memo(ImagePreviewDialog);

--- a/src/standalone/FileUpload/Image/ImageSelector.tsx
+++ b/src/standalone/FileUpload/Image/ImageSelector.tsx
@@ -3,7 +3,6 @@ import {
 	alpha,
 	Box,
 	Button,
-	Dialog,
 	Grid,
 	IconButton,
 	styled,
@@ -14,11 +13,11 @@ import {
 } from "@mui/material";
 import {
 	AttachFile,
-	Close as CloseIcon,
 	FileUpload as UploadIcon,
 	Person,
 	CameraAlt as CameraIcon,
 } from "@mui/icons-material";
+import ImagePreviewDialog from "./ImagePreviewDialog";
 import processImageB64 from "../../../utils/processImageB64";
 import combineClassNames from "../../../utils/combineClassNames";
 import { IDownscaleProps } from "../../../utils/processImage";
@@ -256,20 +255,6 @@ const ModernUploadControlUpload = styled(IconButton, {
 	border: `1px solid ${theme.palette.divider}`,
 }));
 
-const PreviewDialog = styled(Dialog, {
-	name: "CcImageSelector",
-	slot: "previewDialog",
-})({});
-
-const PreviewDialogCloseButton = styled(IconButton, {
-	name: "CcImageSelector",
-	slot: "previewDialogCloseButton",
-})(({ theme }) => ({
-	position: "absolute",
-	top: theme.spacing(2),
-	right: theme.spacing(2),
-}));
-
 export type ImageSelectorClassKey =
 	| "rootClassic"
 	| "rootModern"
@@ -284,8 +269,6 @@ export type ImageSelectorClassKey =
 	| "modernFormatIcon"
 	| "modernUploadControlsWrapper"
 	| "modernUploadControlUpload"
-	| "previewDialog"
-	| "previewDialogCloseButton"
 	| "pfpRoot"
 	| "pfpIconBtn"
 	| "pfpImg"
@@ -401,17 +384,14 @@ const ImageSelector = (inProps: ImageSelectorProps) => {
 	const handlePreviewDialogClose = useCallback(() => {
 		setShowPreviewDialog(false);
 	}, []);
-	const previewDialog = showPreviewDialog && (
-		<PreviewDialog open={true} fullScreen onClose={handlePreviewDialogClose}>
-			<PreviewDialogCloseButton onClick={handlePreviewDialogClose}>
-				<CloseIcon />
-			</PreviewDialogCloseButton>
-			<PreviewModern
-				src={value}
-				alt={props.alt}
-				className={classes?.previewModern}
-			/>
-		</PreviewDialog>
+
+	const previewDialog = variant === "modern" && (
+		<ImagePreviewDialog
+			src={value}
+			alt={props.alt}
+			open={showPreviewDialog}
+			onClose={handlePreviewDialogClose}
+		/>
 	);
 
 	// render component

--- a/src/standalone/FileUpload/MultiImage/ImageBox.tsx
+++ b/src/standalone/FileUpload/MultiImage/ImageBox.tsx
@@ -1,6 +1,5 @@
 import React, {
 	CSSProperties,
-	MutableRefObject,
 	useCallback,
 	useEffect,
 	useRef,
@@ -24,6 +23,7 @@ import {
 import combineClassNames from "../../../utils/combineClassNames";
 import { useDebounce } from "../../../utils/useDebounce";
 import ImageDots, { ImageDotsProps } from "./ImageDots";
+import useImageZoomPan from "../../../utils/useImageZoomPan";
 
 export interface ImageBoxProps {
 	/**
@@ -204,6 +204,22 @@ const FullScreenImageWrapper = styled("div", {
 	position: "relative",
 });
 
+const FullScreenZoomContainer = styled("div", {
+	name: "CcImageBox",
+	slot: "fullScreenZoomContainer",
+})({
+	width: "100%",
+	height: "100%",
+	cursor: "grab",
+	"&:active": {
+		cursor: "grabbing",
+	},
+	"& img": {
+		pointerEvents: "none",
+		userSelect: "none",
+	},
+});
+
 const ImageDotsWrapper = styled("div", {
 	name: "CcImageBox",
 	slot: "imageDotsWrapper",
@@ -236,13 +252,14 @@ export type ImageBoxClassKey =
 	| "image"
 	| "fullScreenDialog"
 	| "fullScreenImageWrapper"
+	| "fullScreenZoomContainer"
 	| "imageDotsWrapper"
 	| "imageDots";
 
 const useScrollSwipe = (
 	params: Pick<ImageBoxProps, "onPrevImage" | "onNextImage">,
 ): {
-	containerRef: MutableRefObject<HTMLDivElement | null>;
+	containerRef: React.RefObject<HTMLDivElement | null>;
 	handleScroll: React.UIEventHandler<HTMLDivElement>;
 	handleTouchEnd: React.TouchEventHandler<HTMLDivElement>;
 } => {
@@ -358,6 +375,12 @@ const ImageBox = (inProps: ImageBoxProps) => {
 		handleTouchEnd: handleTouchEndFS,
 	} = useScrollSwipe(props);
 
+	const {
+		imgRef: zoomImgRef,
+		containerRef: zoomContainerRef,
+		containerProps: zoomContainerProps,
+	} = useImageZoomPan(dialogOpen);
+
 	return (
 		<>
 			<Root
@@ -434,16 +457,24 @@ const ImageBox = (inProps: ImageBoxProps) => {
 								ref={containerRefFS}
 								onTouchEnd={handleTouchEndFS}
 							>
-								<StyledImage
-									src={image}
-									alt={""}
-									ownerState={{
-										swipeLeft: !!onPrevImage,
-										swipeRight: !!onNextImage,
-										imageDots: !imageDots,
-									}}
-									className={classes?.image}
-								/>
+								<FullScreenZoomContainer
+									ref={zoomContainerRef}
+									{...zoomContainerProps}
+									className={classes?.fullScreenZoomContainer}
+								>
+									<StyledImage
+										ref={zoomImgRef}
+										src={image}
+										alt={""}
+										draggable={false}
+										ownerState={{
+											swipeLeft: !!onPrevImage,
+											swipeRight: !!onNextImage,
+											imageDots: !imageDots,
+										}}
+										className={classes?.image}
+									/>
+								</FullScreenZoomContainer>
 							</SwipeListener>
 							<RemoveButton
 								onClick={closeDialog}

--- a/src/standalone/FileUpload/index.ts
+++ b/src/standalone/FileUpload/index.ts
@@ -1,4 +1,5 @@
 export { default as FileUploadGeneric } from "./Generic";
 export { default as ImageSelector } from "./Image/ImageSelector";
+export { default as ImagePreviewDialog } from "./Image/ImagePreviewDialog";
 export * from "./MultiImage";
 export * from "./FileIcons";

--- a/src/theme-def.ts
+++ b/src/theme-def.ts
@@ -8,6 +8,10 @@ import {
 	ImageSelectorProps,
 } from "./standalone/FileUpload/Image/ImageSelector";
 import {
+	ImagePreviewDialogClassKey,
+	ImagePreviewDialogProps,
+} from "./standalone/FileUpload/Image/ImagePreviewDialog";
+import {
 	MultiImageClassKey,
 	MultiImageProps,
 } from "./standalone/FileUpload/MultiImage/MultiImage";
@@ -266,6 +270,7 @@ declare module "@mui/material/styles" {
 		CcDialogTitle: DialogTitleClassKey;
 		CcFileUpload: FileUploadClassKey;
 		CcImageSelector: ImageSelectorClassKey;
+		CcImagePreviewDialog: ImagePreviewDialogClassKey;
 		CcPortalMenu: PortalMenuClassKey;
 		CcMenuItemMaterial: MenuItemMaterialClassKey;
 		CcLocalizedKeyboardDatePicker: LocalizedKeyboardDatePickerClassKey;
@@ -332,6 +337,7 @@ declare module "@mui/material/styles" {
 		CcDialogTitle: Partial<DialogTitleProps>;
 		CcFileUpload: Partial<FileUploadProps>;
 		CcImageSelector: Partial<ImageSelectorProps>;
+		CcImagePreviewDialog: Partial<ImagePreviewDialogProps>;
 		CcPortalMenu: Partial<PortalMenuProps>;
 		CcMenuItemMaterial: Partial<MenuItemMaterialProps>;
 		CcLocalizedKeyboardDatePicker: Partial<LocalizedKeyboardDatePickerProps>;
@@ -544,6 +550,11 @@ declare module "@mui/material/styles" {
 			defaultProps?: ComponentsPropsList["CcImageSelector"];
 			styleOverrides?: ComponentsOverrides<Theme>["CcImageSelector"];
 			variants?: ComponentsVariants["CcImageSelector"];
+		};
+		CcImagePreviewDialog?: {
+			defaultProps?: ComponentsPropsList["CcImagePreviewDialog"];
+			styleOverrides?: ComponentsOverrides<Theme>["CcImagePreviewDialog"];
+			variants?: ComponentsVariants["CcImagePreviewDialog"];
 		};
 		CcPortalMenu?: {
 			defaultProps?: ComponentsPropsList["CcPortalMenu"];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,3 +61,4 @@ export { default as semaphoreExec } from "./semaphoreExec";
 export { default as advancedEnumValueToBaseSelectorData } from "./advancedEnumValueToBaseSelectorData";
 export { default as getCanImageCapture } from "./getCanImageCapture";
 export { default as useDocumentBody } from "./useDocumentBody";
+export { default as useImageZoomPan } from "./useImageZoomPan";

--- a/src/utils/useImageZoomPan.ts
+++ b/src/utils/useImageZoomPan.ts
@@ -1,0 +1,273 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 10;
+
+const applyTransform = (
+	img: HTMLElement | null,
+	zoom: number,
+	panX: number,
+	panY: number,
+) => {
+	if (!img) return;
+	img.style.transform = `translate(${panX}px, ${panY}px) scale(${zoom})`;
+};
+
+export interface UseImageZoomPanResult {
+	/**
+	 * Callback ref to attach to the zoomable image element
+	 */
+	imgRef: (node: HTMLImageElement | null) => void;
+	/**
+	 * Callback ref to attach to the container element (used for pan clamping and wheel listener)
+	 */
+	containerRef: (node: HTMLDivElement | null) => void;
+	/**
+	 * Container event handlers — spread onto the zoom container element
+	 */
+	containerProps: {
+		onPointerDown: React.PointerEventHandler;
+		onPointerMove: React.PointerEventHandler;
+		onPointerUp: React.PointerEventHandler;
+		onPointerLeave: React.PointerEventHandler;
+		onTouchStart: React.TouchEventHandler;
+		onTouchMove: React.TouchEventHandler;
+		onTouchEnd: React.TouchEventHandler;
+		onDoubleClick: React.MouseEventHandler;
+	};
+}
+
+/**
+ * Hook providing zoom (mouse wheel / pinch) and pan (drag) behavior
+ * for an image element inside a container. Updates are imperative (ref-based)
+ * so no React re-renders occur during interaction.
+ *
+ * At zoom 1x, single-finger touch and single-pointer drag events are not
+ * intercepted, allowing parent scroll-based interactions (e.g. swipe
+ * navigation) to work normally. Pinch gestures and mouse wheel zoom always
+ * work regardless of zoom level.
+ *
+ * @param open Whether the zoomable view is currently active. Resets zoom/pan when transitioning to true.
+ */
+const useImageZoomPan = (open: boolean): UseImageZoomPanResult => {
+	const imgElRef = useRef<HTMLImageElement | null>(null);
+	const containerElRef = useRef<HTMLDivElement | null>(null);
+	const wheelCleanupRef = useRef<(() => void) | null>(null);
+	const zoomRef = useRef(1);
+	const panRef = useRef({ x: 0, y: 0 });
+	const isPanning = useRef(false);
+	const lastPointer = useRef({ x: 0, y: 0 });
+	const lastPinchDist = useRef<number | null>(null);
+	const lastTouchCenter = useRef({ x: 0, y: 0 });
+
+	const syncContainerStyle = useCallback(() => {
+		const el = containerElRef.current;
+		if (!el) return;
+		el.style.touchAction = zoomRef.current > 1 ? "none" : "";
+	}, []);
+
+	const imgRef = useCallback((node: HTMLImageElement | null) => {
+		imgElRef.current = node;
+		if (node) {
+			applyTransform(node, zoomRef.current, panRef.current.x, panRef.current.y);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (open) {
+			zoomRef.current = 1;
+			panRef.current = { x: 0, y: 0 };
+			applyTransform(imgElRef.current, 1, 0, 0);
+			syncContainerStyle();
+		}
+	}, [open, syncContainerStyle]);
+
+	const clampPan = useCallback((x: number, y: number, currentZoom: number) => {
+		if (currentZoom <= 1) return { x: 0, y: 0 };
+		const container = containerElRef.current;
+		if (!container) return { x, y };
+		const rect = container.getBoundingClientRect();
+		const maxPanX = ((currentZoom - 1) * rect.width) / 2;
+		const maxPanY = ((currentZoom - 1) * rect.height) / 2;
+		return {
+			x: Math.max(-maxPanX, Math.min(maxPanX, x)),
+			y: Math.max(-maxPanY, Math.min(maxPanY, y)),
+		};
+	}, []);
+
+	const update = useCallback(
+		(nextZoom: number, nextPanX: number, nextPanY: number) => {
+			const clamped = clampPan(nextPanX, nextPanY, nextZoom);
+			zoomRef.current = nextZoom;
+			panRef.current = clamped;
+			applyTransform(imgElRef.current, nextZoom, clamped.x, clamped.y);
+			syncContainerStyle();
+		},
+		[clampPan, syncContainerStyle],
+	);
+
+	// Callback ref for the container — attaches a native wheel listener with
+	// { passive: false } so preventDefault actually stops the parent
+	// ScrollListener from scrolling. React registers onWheel as passive,
+	// making preventDefault a no-op, so we must use a native listener.
+	const containerRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			// clean up previous listener
+			if (wheelCleanupRef.current) {
+				wheelCleanupRef.current();
+				wheelCleanupRef.current = null;
+			}
+			containerElRef.current = node;
+			if (!node) return;
+			const onWheel = (evt: WheelEvent) => {
+				evt.preventDefault();
+				evt.stopPropagation();
+				const delta = evt.deltaY > 0 ? 0.9 : 1.1;
+				const next = Math.max(
+					MIN_ZOOM,
+					Math.min(MAX_ZOOM, zoomRef.current * delta),
+				);
+				update(next, panRef.current.x, panRef.current.y);
+			};
+			node.addEventListener("wheel", onWheel, { passive: false });
+			wheelCleanupRef.current = () =>
+				node.removeEventListener("wheel", onWheel);
+		},
+		[update],
+	);
+
+	const handlePointerDown = useCallback((evt: React.PointerEvent) => {
+		if (evt.pointerType === "touch") return;
+		if (zoomRef.current <= 1) return;
+		isPanning.current = true;
+		lastPointer.current = { x: evt.clientX, y: evt.clientY };
+	}, []);
+
+	const handlePointerMove = useCallback(
+		(evt: React.PointerEvent) => {
+			if (!isPanning.current || evt.pointerType === "touch") return;
+			const dx = evt.clientX - lastPointer.current.x;
+			const dy = evt.clientY - lastPointer.current.y;
+			lastPointer.current = { x: evt.clientX, y: evt.clientY };
+			update(zoomRef.current, panRef.current.x + dx, panRef.current.y + dy);
+		},
+		[update],
+	);
+
+	const handlePointerUp = useCallback(() => {
+		isPanning.current = false;
+	}, []);
+
+	const getPinchDistance = useCallback((touches: React.TouchList) => {
+		if (touches.length < 2)
+			throw new Error("getPinchDistance requires at least 2 touches");
+		const t0 = touches[0];
+		const t1 = touches[1];
+		return Math.hypot(t1.clientX - t0.clientX, t1.clientY - t0.clientY);
+	}, []);
+
+	const getTouchCenter = useCallback((touches: React.TouchList) => {
+		if (touches.length < 2)
+			throw new Error("getTouchCenter requires at least 2 touches");
+		const t0 = touches[0];
+		const t1 = touches[1];
+		return {
+			x: (t0.clientX + t1.clientX) / 2,
+			y: (t0.clientY + t1.clientY) / 2,
+		};
+	}, []);
+
+	const handleTouchStart = useCallback(
+		(evt: React.TouchEvent) => {
+			if (evt.touches.length === 2) {
+				lastPinchDist.current = getPinchDistance(evt.touches);
+				lastTouchCenter.current = getTouchCenter(evt.touches);
+			} else if (evt.touches.length === 1) {
+				lastPointer.current = {
+					x: evt.touches[0].clientX,
+					y: evt.touches[0].clientY,
+				};
+			}
+		},
+		[getPinchDistance, getTouchCenter],
+	);
+
+	const handleTouchMove = useCallback(
+		(evt: React.TouchEvent) => {
+			if (evt.touches.length === 2 && lastPinchDist.current !== null) {
+				// always intercept pinch
+				evt.preventDefault();
+				const dist = getPinchDistance(evt.touches);
+				const scale = dist / lastPinchDist.current;
+				lastPinchDist.current = dist;
+				const center = getTouchCenter(evt.touches);
+				const dx = center.x - lastTouchCenter.current.x;
+				const dy = center.y - lastTouchCenter.current.y;
+				lastTouchCenter.current = center;
+				const next = Math.max(
+					MIN_ZOOM,
+					Math.min(MAX_ZOOM, zoomRef.current * scale),
+				);
+				update(next, panRef.current.x + dx, panRef.current.y + dy);
+			} else if (evt.touches.length === 1 && zoomRef.current > 1) {
+				// only intercept single-finger drag when zoomed in
+				evt.preventDefault();
+				const dx = evt.touches[0].clientX - lastPointer.current.x;
+				const dy = evt.touches[0].clientY - lastPointer.current.y;
+				lastPointer.current = {
+					x: evt.touches[0].clientX,
+					y: evt.touches[0].clientY,
+				};
+				update(zoomRef.current, panRef.current.x + dx, panRef.current.y + dy);
+			}
+			// at zoom 1x with single finger: don't preventDefault, let parent scroll
+		},
+		[update, getPinchDistance, getTouchCenter],
+	);
+
+	const handleTouchEnd = useCallback((evt: React.TouchEvent) => {
+		if (evt.touches.length < 2) {
+			lastPinchDist.current = null;
+		}
+		if (evt.touches.length === 1) {
+			lastPointer.current = {
+				x: evt.touches[0].clientX,
+				y: evt.touches[0].clientY,
+			};
+		}
+	}, []);
+
+	const handleDoubleClick = useCallback(() => {
+		if (zoomRef.current > 1) {
+			update(1, 0, 0);
+		} else {
+			update(2, 0, 0);
+		}
+	}, [update]);
+
+	const containerProps = useMemo(
+		() => ({
+			onPointerDown: handlePointerDown,
+			onPointerMove: handlePointerMove,
+			onPointerUp: handlePointerUp,
+			onPointerLeave: handlePointerUp,
+			onTouchStart: handleTouchStart,
+			onTouchMove: handleTouchMove,
+			onTouchEnd: handleTouchEnd,
+			onDoubleClick: handleDoubleClick,
+		}),
+		[
+			handlePointerDown,
+			handlePointerMove,
+			handlePointerUp,
+			handleTouchStart,
+			handleTouchMove,
+			handleTouchEnd,
+			handleDoubleClick,
+		],
+	);
+
+	return { imgRef, containerRef, containerProps };
+};
+
+export default useImageZoomPan;


### PR DESCRIPTION
Extract ImagePreviewDialog as a standalone component with fullscreen zoom/pan support. Create shared useImageZoomPan hook for ref-based imperative updates (no re-renders during interaction). Integrate zoom into ImageBox's fullscreen dialog while preserving swipe navigation at 1x zoom. Use native wheel listener with { passive: false } to properly prevent scroll during zoom. Add Storybook stories with interaction tests. Replace 1x1 pixel test images with canvas-generated checkerboard patterns.