### PR TITLE
RoutedMenu: don't mutate the definition prop when sorting

### DIFF
--- a/src/non-standalone/Portal/Menu/index.tsx
+++ b/src/non-standalone/Portal/Menu/index.tsx
@@ -58,7 +58,11 @@ const getMenuRouteParams = (
 	if (!match) {
 		// if this fails, get the closest match we can get
 		exact = false;
-		match = definitions
+		// copy before sort: sort() mutates in place, and `definitions` is the
+		// caller's (memoized) menu definition prop — mutating it permanently
+		// reorders the rendered menu by route length (see resolveLocation, which
+		// already copies).
+		match = [...definitions]
 			.sort((a, b) => (b.route?.length ?? 0) - (a.route?.length ?? 0))
 			.find((entry) => entry.route && doesRouteMatch(entry.route, path));
 	}


### PR DESCRIPTION
getMenuRouteParams sorted `definitions` in place (Array.sort mutates) to find the closest route match. Since `definitions` is the caller's menu definition prop — typically a memoized array — the sort permanently reordered the rendered menu by route length after a click/aux-click.

Copy before sorting, matching the sibling resolveLocation which already does `[...definitions].sort(...)`.